### PR TITLE
Implement file menus and preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ python3 -m pip install pygame PyYAML
 python3 main.py
 ```
 
-Use the number keys **1-9** to choose a group, scroll the left strip with the mouse wheel, and draw using the left mouse button. Hold the middle mouse button to pan. Press **Tab** to hide/show the UI. `Ctrl+S` saves to a quick file.
+Use the number keys **1-9** to choose a group, scroll the left strip with the mouse wheel, and draw using the left mouse button. Hold the middle mouse button to pan. Press **Tab** to hide/show the UI. `Ctrl+S` saves to a quick file. Press **F1** to open the menu bar for saving/loading maps and states, changing modes, and editing preferences.
 
 Configuration is stored in `config/ui.yaml` which defines tile and brush groups as folders of text files acting as image placeholders.
 


### PR DESCRIPTION
## Summary
- add pygame-menu dependency for GUI menus
- implement file, mode, map and session menus with F1 shortcut
- support saving/loading maps or session states via menus
- implement preferences dialog for zoom, pan speed and map size
- track unsaved changes and prompt before clearing
- update README about the F1 menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ddffce2b48325b68970e30dc33017