### PR TITLE
Support png tile assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,6 @@ python3 main.py
 
 Use the number keys **1-9** to choose a group, scroll the left strip with the mouse wheel, and draw using the left mouse button. Hold the middle mouse button to pan. Press **Tab** to hide/show the UI. `Ctrl+S` saves to a quick file. A standard menu bar at the top of the window provides options for saving/loading maps and states, changing modes, and editing preferences.
 
-Configuration is stored in `config/ui.yaml` which defines tile and brush groups as folders of text files acting as image placeholders.
+Configuration is stored in `config/ui.yaml` which defines tile and brush groups as directories of image files (for example `.png` sprites). Older `.txt` placeholders are still supported but no longer required.
 
 Sample images are provided for testing. Saved maps are written to `./maps/quick.json` and saved states to `./map-states/quick.json`.

--- a/icons/tiles/ground_a/0.txt
+++ b/icons/tiles/ground_a/0.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/icons/tiles/ground_a/1.txt
+++ b/icons/tiles/ground_a/1.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/icons/tiles/ground_a/2.txt
+++ b/icons/tiles/ground_a/2.txt
@@ -1,1 +1,0 @@
-placeholder

--- a/main.py
+++ b/main.py
@@ -40,9 +40,14 @@ class Group:
     def load_assets(self):
         if not os.path.isdir(self.dir):
             return
-        files = sorted(
-            [f for f in os.listdir(self.dir) if f.lower().endswith('.txt')]
-        )
+        files = sorted([
+            f
+            for f in os.listdir(self.dir)
+            if any(
+                f.lower().endswith(ext)
+                for ext in (".txt", ".png", ".jpg", ".jpeg", ".bmp", ".gif")
+            )
+        ])
         for fn in files:
             path = os.path.join(self.dir, fn)
             img = load_image(path)


### PR DESCRIPTION
## Summary
- load `.png` and other image formats for tile assets
- document image-based directories in README
- remove sample image files

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686df157da908325a6c5522f308f17d4