### PR TITLE
Fix UI scrolling and icon loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ python3 main.py
 
 Use the number keys **1-9** to choose a group, scroll the left strip with the mouse wheel, and draw using the left mouse button. Hold the middle mouse button to pan. Press **Tab** to hide/show the UI. `Ctrl+S` saves to a quick file. A standard menu bar at the top of the window provides options for saving/loading maps and states, changing modes, and editing preferences.
 
+The vertical panel on the left is referred to as the **asset strip** and the bar at the bottom is the **group bar**. The asset strip lists the individual assets in the currently selected group while the group bar displays up to ten available groups.
+
 Configuration is stored in `config/ui.yaml` which defines tile and brush groups as directories of image files (for example `.png` sprites). Older `.txt` placeholders are still supported but no longer required.
+The `mouse_scroll_multiplier` option in this file controls how sensitive the mouse wheel is when cycling assets.
 
 Sample images are provided for testing. Saved maps are written to `./maps/quick.json` and saved states to `./map-states/quick.json`.

--- a/classes/input_handler.py
+++ b/classes/input_handler.py
@@ -27,8 +27,11 @@ class InputHandler:
 
     # ---------------- internal handlers -----------------
     def _handle_keydown(self, event):
-        if pygame.K_1 <= event.key <= pygame.K_9:
-            idx = event.key - pygame.K_1
+        if pygame.K_1 <= event.key <= pygame.K_9 or pygame.K_KP1 <= event.key <= pygame.K_KP9:
+            if pygame.K_1 <= event.key <= pygame.K_9:
+                idx = event.key - pygame.K_1
+            else:
+                idx = event.key - pygame.K_KP1
             groups = self.app.get_active_groups()
             if idx < len(groups):
                 self.app.selected_group = idx
@@ -60,7 +63,8 @@ class InputHandler:
                 self.app.zoom = self.app.zoom_levels[min(len(self.app.zoom_levels) - 1, self.app.zoom_levels.index(self.app.zoom) + 1)]
             self.app.clamp_camera()
         else:
-            self.app.wheel_accum += event.y
+            multiplier = self.app.config.ui.get('mouse_scroll_multiplier', 1)
+            self.app.wheel_accum += event.y * multiplier
             while self.app.wheel_accum >= 1:
                 self.app.asset_ui.cycle_selected_asset(-1)
                 self.app.wheel_accum -= 1
@@ -78,7 +82,9 @@ class InputHandler:
                     self.app.zoom = self.app.zoom_levels[min(len(self.app.zoom_levels) - 1, self.app.zoom_levels.index(self.app.zoom) + 1)]
                 self.app.clamp_camera()
             else:
-                self.app.asset_ui.cycle_selected_asset(delta)
+                multiplier = self.app.config.ui.get('mouse_scroll_multiplier', 1)
+                for _ in range(int(multiplier)):
+                    self.app.asset_ui.cycle_selected_asset(delta)
         elif event.button == 1:
             self.app.left_button_down = True
             if self.app.mode < 4:

--- a/classes/ui.py
+++ b/classes/ui.py
@@ -46,7 +46,7 @@ class AssetUI:
         assets = groups[self.app.selected_group].assets
         if not assets:
             return
-        self.app.selected_asset = max(0, min(len(assets) - 1, self.app.selected_asset + delta))
+        self.app.selected_asset = (self.app.selected_asset + delta) % len(assets)
         if self.app.selected_asset < self.app.asset_scroll:
             self.app.asset_scroll = self.app.selected_asset
         elif self.app.selected_asset >= self.app.asset_scroll + self.app.config.ui['left_strip_visible_rows']:

--- a/config/ui.yaml
+++ b/config/ui.yaml
@@ -4,7 +4,7 @@ groups:
   tile_groups:
     - key: 1
       id: ground_a
-      icon: icons/groups/ground_a.txt
+      icon: icons/tiles/ground_a/grass1.png
       dir: icons/tiles/ground_a
     - key: 2
       id: ground_b
@@ -28,6 +28,7 @@ ui:
   tile_preview_size: 32
   highlight_color: "#FFD700"
   hotkey_page_keys: [PageUp, PageDown]
+  mouse_scroll_multiplier: 3
 
 general:
   zoom_levels: [0.5, 1, 2]


### PR DESCRIPTION
## Summary
- improve mouse wheel sensitivity and wrap asset scrolling
- allow keypad hotkeys for group selection
- use a real grass icon for the ground group and add scroll multiplier setting
- document UI naming conventions and scroll option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686df77bf58c8325a5bcaff8581fe9d3